### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build Project
+permissions:
+  contents: read
 on:
   push:
     branches: ["master"]


### PR DESCRIPTION
Potential fix for [https://github.com/gvatsal60/tcp-ip-pkt-gen/security/code-scanning/3](https://github.com/gvatsal60/tcp-ip-pkt-gen/security/code-scanning/3)

To fix the issue, add a `permissions` block to the workflow file. This block should specify the minimal permissions required for the workflow to function correctly. Based on the provided workflow, the `contents: read` permission is sufficient for the `actions/checkout` step, and no additional permissions are required for the `make build` and `make test` steps. The `permissions` block can be added at the root level of the workflow to apply to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
