### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/readme-checker.yaml
+++ b/.github/workflows/readme-checker.yaml
@@ -1,4 +1,6 @@
 name: markdown-lint
+permissions:
+  contents: read
 on:
   pull_request:
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/gvatsal60/tcp-ip-pkt-gen/security/code-scanning/2](https://github.com/gvatsal60/tcp-ip-pkt-gen/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only performs linting operations and does not require write access, the permissions can be limited to `contents: read`. This block should be added at the root level of the workflow, ensuring it applies to all jobs within the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
