### PR TITLE
Fix/codacy vg

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,3 +8,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://img.shields.io/github/license/gvatsal60/tcp-ip-pkt-gen)
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/gvatsal60/tcp-ip-pkt-gen/build.yml)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=gvatsal60_tcp-ip-pkt-gen&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=gvatsal60_tcp-ip-pkt-gen)
-[![Maintenance](https://img.shields.io/badge/Maintained%3F-Yes-green.svg)](https://GitHub.com/gvatsal60/tcp-ip-pkt-gen/graphs/commit-activity)
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/a3fcc2ca3efc42819b0c891adc2b39ec)](https://app.codacy.com/gh/gvatsal60/tcp-ip-pkt-gen/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
+[![CodeFactor](https://www.codefactor.io/repository/github/gvatsal60/tcp-ip-pkt-gen/badge)](https://www.codefactor.io/repository/github/gvatsal60/tcp-ip-pkt-gen)
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/gvatsal60/tcp-ip-pkt-gen/master.svg)](https://results.pre-commit.ci/latest/github/gvatsal60/tcp-ip-pkt-gen/master)
 [![GitHub pull-requests](https://img.shields.io/github/issues-pr/gvatsal60/tcp-ip-pkt-gen.svg)](https://GitHub.com/gvatsal60/tcp-ip-pkt-gen/pull/)
 [![GitHub issues](https://img.shields.io/github/issues/gvatsal60/tcp-ip-pkt-gen.svg)](https://GitHub.com/gvatsal60/tcp-ip-pkt-gen/issues/)
 [![GitHub forks](https://img.shields.io/github/forks/gvatsal60/tcp-ip-pkt-gen.svg)](https://GitHub.com/gvatsal60/tcp-ip-pkt-gen/network/)
@@ -55,4 +57,4 @@ Contributions are welcome! If you have suggestions for improvements, bug fixes, 
 
 ## License
 
-This project is licensed under the [Apache License](https://github.com/gvatsal60/tcp-ip-pkt-gen/blob/master/LICENSE).
+This project is licensed under the Apache 2.0 License. See [LICENSE](LICENSE) for details.

--- a/dockerfiles/Dockerfile.alpine
+++ b/dockerfiles/Dockerfile.alpine
@@ -8,41 +8,41 @@ LABEL DESCRIPTION="Build Environment"
 
 # Update and install necessary packages
 RUN apk update && \
-    apk upgrade && \
-    # Install necessary tools
-    apk add --no-cache \
-    git \
-    build-base \
-    cmake \
-    clang \
-    openssl \
-    openssl-dev \
-    openjdk11 \
-    python3 \
-    xz \
-    net-tools \
-    gtest \
-    gtest-dev \
-    && \
-    # Clean up
-    rm -rf /var/cache/apk/* && \
-    # Create a non-root user
-    adduser -D nonroot
+  apk upgrade && \
+  # Install necessary tools
+  apk add --no-cache \
+  build-base \
+  clang \
+  cmake \
+  git \
+  gtest \
+  gtest-dev \
+  net-tools \
+  openjdk11 \
+  openssl \
+  openssl-dev \
+  python3 \
+  xz \
+  && \
+  # Clean up
+  rm -rf /var/cache/apk/* && \
+  # Create a non-root user
+  adduser -D nonroot
 
 # Install gtest
 FROM base AS gtest
 ARG GTEST_VER=v1.14.0
 RUN set -x && \
-    SRC=/usr/local/src/google-test-${GTEST_VER} && \
-    mkdir -p "$SRC" && cd "$SRC" && \
-    # Download and extract gtest source code
-    wget -O - https://github.com/google/googletest/archive/${GTEST_VER}.tar.gz \
-    | tar xz -C "$SRC" --strip-components=1 && \
-    # Create build directory and compile gtest
-    mkdir build && \
-    cd build && \
-    cmake .. && \
-    make -j8 && make install DESTDIR=/opt/gtest
+  SRC=/usr/local/src/google-test-${GTEST_VER} && \
+  mkdir -p "$SRC" && cd "$SRC" && \
+  # Download and extract gtest source code
+  wget --secure-protocol=TLSv1_2 --max-redirect=0 -q -O - https://github.com/google/googletest/archive/${GTEST_VER}.tar.gz \
+  | tar xz -C "$SRC" --strip-components=1 && \
+  # Create build directory and compile gtest
+  mkdir build && \
+  cd build && \
+  cmake .. && \
+  make -j8 && make install DESTDIR=/opt/gtest
 
 # Build Final Image
 FROM base AS build

--- a/dockerfiles/Dockerfile.debug
+++ b/dockerfiles/Dockerfile.debug
@@ -1,18 +1,17 @@
-FROM mcr.microsoft.com/devcontainers/cpp:latest AS base
+FROM mcr.microsoft.com/devcontainers/cpp:debian AS base
 
 # Metadata indicating the maintainer of this Dockerfile
 LABEL MAINTAINER="gvatsal60"
 # Description of the purpose of this image
 LABEL DESCRIPTION="Build Environment"
 
-ARG USERNAME=vscode
-
-ARG GTEST_DEST=/opt/gtest
-
 # Install dependencies
+RUN curl --proto "=https" --tlsv1.2 -sSf -L https://deb.nodesource.com/setup_lts.x | bash -
+
 RUN apt-get update \
   && apt-get -y install --no-install-recommends \
   bear \
+  nodejs \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
@@ -22,6 +21,7 @@ ARG GTEST_VER=1.15.2
 ARG GTEST_TAR_VER=v${GTEST_VER}.tar.gz
 ARG GTEST_BUILD_DIR=googletest-${GTEST_VER}/build
 ARG GTEST_SRC=/usr/local/src
+ARG GTEST_DEST=/opt/gtest
 
 # Download and extract gtest source code using ADD
 ADD https://github.com/google/googletest/archive/${GTEST_TAR_VER} ${GTEST_SRC}
@@ -43,4 +43,5 @@ FROM base AS build
 COPY --from=gtest ${GTEST_DEST} /
 
 # Switch to non-root user
+ARG USERNAME=vscode
 USER ${USERNAME}

--- a/dockerfiles/Dockerfile.debug
+++ b/dockerfiles/Dockerfile.debug
@@ -6,9 +6,8 @@ LABEL MAINTAINER="gvatsal60"
 LABEL DESCRIPTION="Build Environment"
 
 # Install dependencies
-RUN curl --proto "=https" --tlsv1.2 -sSf -L https://deb.nodesource.com/setup_lts.x | bash -
-
-RUN apt-get update \
+RUN curl --proto "=https" --tlsv1.2 -sSf -L https://deb.nodesource.com/setup_lts.x | bash - \
+  && apt-get update \
   && apt-get -y install --no-install-recommends \
   bear \
   nodejs \

--- a/tcp-ip-pkt-gen/inc/packet_gen.hpp
+++ b/tcp-ip-pkt-gen/inc/packet_gen.hpp
@@ -34,7 +34,7 @@ private:
   GenerateUdpIpPacket(const uint8_t *const data, const size_t data_len,
                       const uint32_t source_ip, const uint32_t dest_ip,
                       const uint16_t source_port, const uint16_t dest_port);
-  uint16_t CheckSum(const uint16_t *data, size_t length);
+  uint16_t CheckSum(const uint16_t *data, size_t length) const;
 
   /* Default window size for TCP packets. */
   const uint32_t DEFAULT_WINDOW_SIZE = 65535;

--- a/tcp-ip-pkt-gen/inc/packet_gen.hpp
+++ b/tcp-ip-pkt-gen/inc/packet_gen.hpp
@@ -3,7 +3,6 @@
 #define PACKET_GEN_HPP
 
 #include <memory>
-#include <string>
 #include <string_view>
 
 /**

--- a/tcp-ip-pkt-gen/src/main.cpp
+++ b/tcp-ip-pkt-gen/src/main.cpp
@@ -5,7 +5,6 @@
 
 #include <cassert>
 #include <iostream>
-#include <memory>
 
 #include "packet_gen.hpp"
 #include "utils.hpp"

--- a/tcp-ip-pkt-gen/src/packet_gen.cpp
+++ b/tcp-ip-pkt-gen/src/packet_gen.cpp
@@ -7,7 +7,6 @@
 #include <unistd.h>
 
 #include <cstring>
-#include <memory>
 
 /**
  * @brief Calculate checksum for a given data buffer.

--- a/tcp-ip-pkt-gen/src/packet_gen.cpp
+++ b/tcp-ip-pkt-gen/src/packet_gen.cpp
@@ -18,7 +18,7 @@
  * @param length Length of the data buffer in bytes.
  * @return The calculated checksum value.
  */
-uint16_t Packet_Generator::CheckSum(const uint16_t *data, size_t length) {
+uint16_t Packet_Generator::CheckSum(const uint16_t *data, size_t length) const {
   uint32_t sum = 0;
 
   while (length > 1) {


### PR DESCRIPTION
This pull request introduces several improvements across documentation, Docker setup, and code quality. The main changes include enhancements to CI badges in the `README.md`, updates to Dockerfiles for better dependency management and security, and minor code cleanups to improve maintainability and correctness.

**Documentation and CI Badges:**

* Added Codacy, CodeFactor, and pre-commit.ci badges to `README.md` for improved code quality visibility, and clarified the license section. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L6-R8) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L58-R60)

**Dependency and Build System Updates:**

* Added Docker support to Dependabot configuration to enable automated Docker dependency updates.
* Improved `dockerfiles/Dockerfile.alpine` by updating package installation order, explicitly adding `gtest` and related tools, and making the `wget` command more secure. [[1]](diffhunk://#diff-7c4626c61a517809cfc70ee446fa8ddd17ec7b3ea6334a4e8e4a913d33c698d1L14-L25) [[2]](diffhunk://#diff-7c4626c61a517809cfc70ee446fa8ddd17ec7b3ea6334a4e8e4a913d33c698d1L39-R39)
* Updated `dockerfiles/Dockerfile.debug` to use the `debian` tag for the base image, install Node.js, and clean up build arguments and environment variables for consistency and clarity. [[1]](diffhunk://#diff-d5614b091fef9f82cf3b2ae0c426bd2977217e1bb1fcfc378768d809f1f71730L1-R13) [[2]](diffhunk://#diff-d5614b091fef9f82cf3b2ae0c426bd2977217e1bb1fcfc378768d809f1f71730R23) [[3]](diffhunk://#diff-d5614b091fef9f82cf3b2ae0c426bd2977217e1bb1fcfc378768d809f1f71730R45)

**Code Quality and Maintainability:**

* Removed unnecessary `#include <memory>` directives from several source files, and made the `CheckSum` method in `Packet_Generator` a `const` method for correctness. [[1]](diffhunk://#diff-8f4b09ca22b9b53f52824626232300ee81c6564d7b3d728ca4284a73b1a4180eL6) [[2]](diffhunk://#diff-8f4b09ca22b9b53f52824626232300ee81c6564d7b3d728ca4284a73b1a4180eL38-R37) [[3]](diffhunk://#diff-a187655edd24a776b167886774931da85797b6815ff8d18d1992d9ad9ab6a515L8) [[4]](diffhunk://#diff-90b89525f49b5f2f2dcb8472ac384ae232cfd954c16b4319aaca0fc007091b3cL10) [[5]](diffhunk://#diff-90b89525f49b5f2f2dcb8472ac384ae232cfd954c16b4319aaca0fc007091b3cL22-R21)