### PR TITLE
Update devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,7 +21,7 @@
       ],
       "settings": {
         "[cpp]": {
-          "editor.defaultFormatter": "ms-vscode.cpptools"
+          "editor.defaultFormatter": "llvm-vs-code-extensions.vscode-clangd"
         },
         "[dockercompose]": {
           "editor.autoIndent": "advanced",


### PR DESCRIPTION
This pull request updates the default code formatter for C++ files in the development container configuration. The new formatter provides improved formatting consistency and better integration with modern C++ tooling.

* Development environment configuration:
  * [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L24-R24): Changed the C++ default formatter from `ms-vscode.cpptools` to `llvm-vs-code-extensions.vscode-clangd` for enhanced formatting support.