### PR TITLE
Fix/compiler vg

### DIFF
--- a/tcp-ip-pkt-gen/Makefile
+++ b/tcp-ip-pkt-gen/Makefile
@@ -1,6 +1,6 @@
 # Compiler and flags
 CXX := g++
-CXXFLAGS := -std=c++2a -Wall -Wextra -g
+CXXFLAGS := -std=c++17 -Wall -Wextra -g
 LDFLAGS := -lgtest -lgtest_main -pthread
 
 MKDIR := mkdir -p

--- a/tcp-ip-pkt-gen/src/main.cpp
+++ b/tcp-ip-pkt-gen/src/main.cpp
@@ -88,7 +88,7 @@ int main(const int argc, const char *const argv[]) {
       pkt_args.payload.size(), pkt_args.src_addr, pkt_args.dst_addr,
       pkt_args.src_port, pkt_args.dst_port);
 
-  if (out_data.get()) {
+  if (out_data != nullptr) {
     PrintHexBuffer(out_data.get(),
                    pkt_args.payload.size() + (sizeof(ip) + sizeof(tcphdr)));
   } else {

--- a/tcp-ip-pkt-gen/src/main.cpp
+++ b/tcp-ip-pkt-gen/src/main.cpp
@@ -27,10 +27,36 @@ inline void PrintUsage(const char *program_name) {
             << std::endl;
 }
 
+bool HandleArgument(const std::string &arg, const char *value,
+                    PktArguments &pkt_args) {
+  if (arg == "--source" || arg == "--src") {
+    if (inet_pton(AF_INET, value, &pkt_args.src_addr) != 1)
+      return false;
+    pkt_args.src_addr = ntohl(pkt_args.src_addr);
+  } else if (arg == "--destination" || arg == "--dst") {
+    if (inet_pton(AF_INET, value, &pkt_args.dst_addr) != 1)
+      return false;
+    pkt_args.dst_addr = ntohl(pkt_args.dst_addr);
+  } else if (arg == "--src_port") {
+    pkt_args.src_port = std::stoi(value);
+  } else if (arg == "--dst_port") {
+    pkt_args.dst_port = std::stoi(value);
+  } else if (arg == "--protocol") {
+    pkt_args.protocol = value;
+  } else if (arg == "--payload") {
+    pkt_args.payload = value;
+  } else {
+    std::cerr << "Invalid argument: " << arg << std::endl;
+    return false;
+  }
+
+  return true;
+}
+
 bool ParseArguments(int argc, const char *const argv[],
                     PktArguments &pkt_args) {
-  constexpr int kMaxArgSupported = 13;
-  if (argc != kMaxArgSupported) {
+
+  if (constexpr int kMaxArgSupported = 13; argc != kMaxArgSupported) {
     return false;
   }
 
@@ -38,22 +64,7 @@ bool ParseArguments(int argc, const char *const argv[],
     const std::string arg = argv[i];
     const char *value = argv[i + 1];
 
-    if ((arg == "--source") || (arg == "--src")) {
-      inet_pton(AF_INET, value, &pkt_args.src_addr);
-      pkt_args.src_addr = ntohl(pkt_args.src_addr);
-    } else if ((arg == "--destination") || (arg == "--dst")) {
-      inet_pton(AF_INET, value, &pkt_args.dst_addr);
-      pkt_args.dst_addr = ntohl(pkt_args.dst_addr);
-    } else if (arg == "--src_port") {
-      pkt_args.src_port = std::stoi(value);
-    } else if (arg == "--dst_port") {
-      pkt_args.dst_port = std::stoi(value);
-    } else if (arg == "--protocol") {
-      pkt_args.protocol = value;
-    } else if (arg == "--payload") {
-      pkt_args.payload = value;
-    } else {
-      std::cerr << "Invalid argument: " << arg << std::endl;
+    if (!HandleArgument(arg, value, pkt_args)) {
       return false;
     }
   }

--- a/tcp-ip-pkt-gen/src/packet_gen.cpp
+++ b/tcp-ip-pkt-gen/src/packet_gen.cpp
@@ -7,6 +7,7 @@
 #include <unistd.h>
 
 #include <cstring>
+#include <iostream>
 
 /**
  * @brief Calculate checksum for a given data buffer.


### PR DESCRIPTION
This pull request focuses on code quality improvements and refactoring in the `tcp-ip-pkt-gen` project, primarily targeting argument parsing robustness, code clarity, and standards compliance. The main changes include splitting argument handling into a dedicated function, improving error checking, updating the C++ standard version, and minor code and include cleanups.

**Argument Parsing Improvements:**
* Refactored argument parsing by moving individual argument handling to a new `HandleArgument` function, which improves code readability and maintainability. Added error checking for IP address parsing to ensure invalid addresses are detected early. (`tcp-ip-pkt-gen/src/main.cpp`)
* Updated the `ParseArguments` function to use the new handler and return false immediately on any invalid argument, further improving robustness. (`tcp-ip-pkt-gen/src/main.cpp`)

**Code Quality and Standards:**
* Changed the C++ standard from C++20 (`-std=c++2a`) to C++17 (`-std=c++17`) in the `Makefile` for better compatibility. (`tcp-ip-pkt-gen/Makefile`)
* Improved pointer checks in `main` by using `out_data != nullptr` instead of `out_data.get()` for clarity. (`tcp-ip-pkt-gen/src/main.cpp`)

**Include Cleanups:**
* Added missing `#include <iostream>` to `packet_gen.cpp` to ensure proper use of standard output streams. (`tcp-ip-pkt-gen/src/packet_gen.cpp`)